### PR TITLE
Add missing Kafka dependencies to common module

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -8,4 +8,14 @@
   </parent>
   <artifactId>common</artifactId>
   <name>common</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+  </dependencies>
 </project>


### PR DESCRIPTION
## Summary
- include Kafka clients and Jackson dependencies in common module to support header and serializer utilities

## Testing
- `mvn -pl common test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-failsafe-plugin:pom:3.2.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896e7d9ea8883298bbbf09517b42e1d