### PR TITLE
Add missing test dependencies for common module

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -17,5 +17,15 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>kafka</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
## Summary
- add JUnit Jupiter and Testcontainers Kafka dependencies to common module test scope

## Testing
- `mvn -q -pl common test` *(fails: Plugin org.apache.maven.plugins:maven-failsafe-plugin:3.2.5 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68976a5e3c408329ae94b382999ccc03