### PR TITLE
Handle null values in stateless transform TopologyBuilder

### DIFF
--- a/stateless-transforms/src/main/java/io/example/kstreamspatterns/statelesstransforms/TopologyBuilder.java
+++ b/stateless-transforms/src/main/java/io/example/kstreamspatterns/statelesstransforms/TopologyBuilder.java
@@ -13,7 +13,8 @@ public final class TopologyBuilder {
     StreamsBuilder builder = new StreamsBuilder();
     builder
         .stream(input, org.apache.kafka.streams.kstream.Consumed.with(Serdes.String(), Serdes.String()))
-        .mapValues(String::toUpperCase)
+        // Guard against null values before applying transformations to avoid NullPointerExceptions.
+        .mapValues(v -> v == null ? null : v.toUpperCase())
         .filter((k, v) -> v != null && !v.startsWith("IGNORE"))
         .flatMapValues(v -> java.util.Arrays.asList(v.split(" ")))
         .to(output);


### PR DESCRIPTION
## Summary
- prevent NullPointerException when input values are null in stateless transforms topology

## Testing
- `mvn -q -e -pl stateless-transforms -am -DskipTests package` *(fails: Could not transfer artifact maven-failsafe-plugin due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68976d445a14832997053ff094466872