### PR TITLE
Filter out null deduplicated records

### DIFF
--- a/deduplication/src/main/java/io/example/kstreamspatterns/deduplication/TopologyBuilder.java
+++ b/deduplication/src/main/java/io/example/kstreamspatterns/deduplication/TopologyBuilder.java
@@ -32,7 +32,9 @@ public final class TopologyBuilder {
     KStream<String, String> source =
         builder.stream(input, Consumed.with(Serdes.String(), Serdes.String()));
     KStream<String, String> deduped =
-        source.transformValues(new DeduplicationSupplier(Duration.ofMinutes(10)), "dedup-store");
+        source
+            .transformValues(new DeduplicationSupplier(Duration.ofMinutes(10)), "dedup-store")
+            .filter((key, value) -> value != null);
     deduped.to(output, Produced.with(Serdes.String(), Serdes.String()));
     return builder.build();
   }


### PR DESCRIPTION
## Summary
- filter out deduplicated tombstone records before writing to the output topic

## Testing
- `mvn -q -pl deduplication test` *(fails: Plugin org.apache.maven.plugins:maven-failsafe-plugin:3.2.5 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-failsafe-plugin:pom:3.2.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*
- `mvn -q -pl deduplication -am -DskipTests spotless:apply` *(fails: No plugin found for prefix 'spotless'...)*

------
https://chatgpt.com/codex/tasks/task_e_68976f556de48329955cab64108dceb2