### PR TITLE
Scope common dependency for tests

### DIFF
--- a/agg-window-hopping/pom.xml
+++ b/agg-window-hopping/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/agg-window-session/pom.xml
+++ b/agg-window-session/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/agg-window-tumbling/pom.xml
+++ b/agg-window-tumbling/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/aggregate-reduce-count/pom.xml
+++ b/aggregate-reduce-count/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/aggregate-reduce-count/src/main/java/io/example/kstreamspatterns/aggregatereducecount/TopologyBuilder.java
+++ b/aggregate-reduce-count/src/main/java/io/example/kstreamspatterns/aggregatereducecount/TopologyBuilder.java
@@ -19,9 +19,18 @@ public final class TopologyBuilder {
         builder
             .stream(input, Consumed.with(Serdes.String(), Serdes.Long()))
             .groupByKey();
-    grouped.aggregate(() -> 0L, (k, v, agg) -> agg + v).toStream().to(sum);
-    grouped.reduce(Long::max).toStream().to(max);
-    grouped.count().toStream().to(count);
+    grouped
+        .aggregate(() -> 0L, (k, v, agg) -> agg + v)
+        .toStream()
+        .to(sum, org.apache.kafka.streams.kstream.Produced.with(Serdes.String(), Serdes.Long()));
+    grouped
+        .reduce(Long::max)
+        .toStream()
+        .to(max, org.apache.kafka.streams.kstream.Produced.with(Serdes.String(), Serdes.Long()));
+    grouped
+        .count()
+        .toStream()
+        .to(count, org.apache.kafka.streams.kstream.Produced.with(Serdes.String(), Serdes.Long()));
     return builder.build();
   }
 }

--- a/branch-route/pom.xml
+++ b/branch-route/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/branch-route/src/main/java/io/example/kstreamspatterns/branchroute/TopologyBuilder.java
+++ b/branch-route/src/main/java/io/example/kstreamspatterns/branchroute/TopologyBuilder.java
@@ -26,8 +26,8 @@ public final class TopologyBuilder {
               }
             },
             (k, v) -> true);
-    branches[0].to(even);
-    branches[1].to(odd);
+    branches[0].to(even, org.apache.kafka.streams.kstream.Produced.with(Serdes.String(), Serdes.String()));
+    branches[1].to(odd, org.apache.kafka.streams.kstream.Produced.with(Serdes.String(), Serdes.String()));
     return builder.build();
   }
 }

--- a/branch-route/src/test/java/io/example/kstreamspatterns/branchroute/BranchRouteIT.java
+++ b/branch-route/src/test/java/io/example/kstreamspatterns/branchroute/BranchRouteIT.java
@@ -60,11 +60,13 @@ public class BranchRouteIT extends KafkaIntegrationTest {
       consumer.subscribe(Arrays.asList("even-branch-it", "odd-branch-it"));
       ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
       List<String> evenValues =
-          records.records("even-branch-it").stream()
+          java.util.stream.StreamSupport
+              .stream(records.records("even-branch-it").spliterator(), false)
               .map(ConsumerRecord::value)
               .collect(Collectors.toList());
       List<String> oddValues =
-          records.records("odd-branch-it").stream()
+          java.util.stream.StreamSupport
+              .stream(records.records("odd-branch-it").spliterator(), false)
               .map(ConsumerRecord::value)
               .collect(Collectors.toList());
       assertThat(evenValues).containsExactly("2");

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -28,4 +28,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/deduplication/pom.xml
+++ b/deduplication/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/deduplication/src/test/java/io/example/kstreamspatterns/deduplication/DeduplicationIT.java
+++ b/deduplication/src/test/java/io/example/kstreamspatterns/deduplication/DeduplicationIT.java
@@ -60,7 +60,8 @@ public class DeduplicationIT extends KafkaIntegrationTest {
       consumer.subscribe(List.of("output-dedup-it"));
       ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
       List<String> values =
-          records.records("output-dedup-it").stream()
+          java.util.stream.StreamSupport
+              .stream(records.records("output-dedup-it").spliterator(), false)
               .map(ConsumerRecord::value)
               .collect(Collectors.toList());
       assertThat(values).containsExactly("a", "c");

--- a/enrichment-globalktable/pom.xml
+++ b/enrichment-globalktable/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/enrichment-globalktable/src/main/java/io/example/kstreamspatterns/enrichmentglobalktable/TopologyBuilder.java
+++ b/enrichment-globalktable/src/main/java/io/example/kstreamspatterns/enrichmentglobalktable/TopologyBuilder.java
@@ -24,7 +24,7 @@ public final class TopologyBuilder {
             productTable,
             (key, value) -> key,
             (order, name) -> name == null ? "unknown:" + order : name + ":" + order)
-        .to(output);
+        .to(output, org.apache.kafka.streams.kstream.Produced.with(Serdes.String(), Serdes.String()));
     return builder.build();
   }
 }

--- a/enrichment-globalktable/src/test/java/io/example/kstreamspatterns/enrichmentglobalktable/EnrichmentGlobalKTableIT.java
+++ b/enrichment-globalktable/src/test/java/io/example/kstreamspatterns/enrichmentglobalktable/EnrichmentGlobalKTableIT.java
@@ -54,7 +54,10 @@ public class EnrichmentGlobalKTableIT extends KafkaIntegrationTest {
     try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consProps)) {
       consumer.subscribe(Collections.singleton("enriched-orders-gkt-it"));
       ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
-      assertThat(records.records("enriched-orders-gkt-it").stream().map(ConsumerRecord::value))
+      assertThat(
+              java.util.stream.StreamSupport
+                  .stream(records.records("enriched-orders-gkt-it").spliterator(), false)
+                  .map(ConsumerRecord::value))
           .contains("apple:5");
     }
 

--- a/enrichment-ktable/pom.xml
+++ b/enrichment-ktable/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/enrichment-ktable/src/main/java/io/example/kstreamspatterns/enrichmentktable/TopologyBuilder.java
+++ b/enrichment-ktable/src/main/java/io/example/kstreamspatterns/enrichmentktable/TopologyBuilder.java
@@ -23,7 +23,7 @@ public final class TopologyBuilder {
         .leftJoin(
             productTable,
             (order, name) -> name == null ? "unknown:" + order : name + ":" + order)
-        .to(output);
+        .to(output, org.apache.kafka.streams.kstream.Produced.with(Serdes.String(), Serdes.String()));
     return builder.build();
   }
 }

--- a/enrichment-ktable/src/test/java/io/example/kstreamspatterns/enrichmentktable/EnrichmentKTableIT.java
+++ b/enrichment-ktable/src/test/java/io/example/kstreamspatterns/enrichmentktable/EnrichmentKTableIT.java
@@ -54,7 +54,10 @@ public class EnrichmentKTableIT extends KafkaIntegrationTest {
     try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consProps)) {
       consumer.subscribe(Collections.singleton("enriched-orders-it"));
       ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
-      assertThat(records.records("enriched-orders-it").stream().map(ConsumerRecord::value))
+      assertThat(
+              java.util.stream.StreamSupport
+                  .stream(records.records("enriched-orders-it").spliterator(), false)
+                  .map(ConsumerRecord::value))
           .contains("apple:5");
     }
 

--- a/exactly-once-outbox/pom.xml
+++ b/exactly-once-outbox/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/exactly-once-outbox/src/main/java/io/example/kstreamspatterns/exactlyonceoutbox/TopologyBuilder.java
+++ b/exactly-once-outbox/src/main/java/io/example/kstreamspatterns/exactlyonceoutbox/TopologyBuilder.java
@@ -16,8 +16,8 @@ public final class TopologyBuilder {
         builder
             .stream(input, org.apache.kafka.streams.kstream.Consumed.with(Serdes.String(), Serdes.String()))
             .mapValues(String::toUpperCase);
-    stream.to(processed);
-    stream.to(outbox);
+    stream.to(processed, org.apache.kafka.streams.kstream.Produced.with(Serdes.String(), Serdes.String()));
+    stream.to(outbox, org.apache.kafka.streams.kstream.Produced.with(Serdes.String(), Serdes.String()));
     return builder.build();
   }
 }

--- a/exactly-once-outbox/src/test/java/io/example/kstreamspatterns/exactlyonceoutbox/ExactlyOnceOutboxIT.java
+++ b/exactly-once-outbox/src/test/java/io/example/kstreamspatterns/exactlyonceoutbox/ExactlyOnceOutboxIT.java
@@ -53,13 +53,19 @@ public class ExactlyOnceOutboxIT extends KafkaIntegrationTest {
     try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consProps)) {
       consumer.subscribe(Collections.singleton("orders-proc"));
       ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
-      assertThat(records.records("orders-proc").stream().map(ConsumerRecord::value))
+      assertThat(
+              java.util.stream.StreamSupport
+                  .stream(records.records("orders-proc").spliterator(), false)
+                  .map(ConsumerRecord::value))
           .containsExactly("ITEM");
     }
     try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consProps)) {
       consumer.subscribe(Collections.singleton("orders-out"));
       ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
-      assertThat(records.records("orders-out").stream().map(ConsumerRecord::value))
+      assertThat(
+              java.util.stream.StreamSupport
+                  .stream(records.records("orders-out").spliterator(), false)
+                  .map(ConsumerRecord::value))
           .containsExactly("ITEM");
     }
 

--- a/fanout-fanin/pom.xml
+++ b/fanout-fanin/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/fanout-fanin/src/main/java/io/example/kstreamspatterns/fanoutfanin/TopologyBuilder.java
+++ b/fanout-fanin/src/main/java/io/example/kstreamspatterns/fanoutfanin/TopologyBuilder.java
@@ -39,7 +39,8 @@ public final class TopologyBuilder {
               }
             });
 
-    even.merge(odd).to(output);
+    even.merge(odd)
+        .to(output, org.apache.kafka.streams.kstream.Produced.with(Serdes.String(), Serdes.String()));
     return builder.build();
   }
 }

--- a/fanout-fanin/src/test/java/io/example/kstreamspatterns/fanoutfanin/FanoutFaninIT.java
+++ b/fanout-fanin/src/test/java/io/example/kstreamspatterns/fanoutfanin/FanoutFaninIT.java
@@ -58,7 +58,8 @@ public class FanoutFaninIT extends KafkaIntegrationTest {
       consumer.subscribe(List.of("fanout-output-it"));
       ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
       List<String> values =
-          records.records("fanout-output-it").stream()
+          java.util.stream.StreamSupport
+              .stream(records.records("fanout-output-it").spliterator(), false)
               .map(ConsumerRecord::value)
               .collect(Collectors.toList());
       assertThat(values).containsExactly("3", "4", "9");

--- a/join-kstream-kstream/pom.xml
+++ b/join-kstream-kstream/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/join-kstream-kstream/src/main/java/io/example/kstreamspatterns/joinkstreamkstream/TopologyBuilder.java
+++ b/join-kstream-kstream/src/main/java/io/example/kstreamspatterns/joinkstreamkstream/TopologyBuilder.java
@@ -27,7 +27,7 @@ public final class TopologyBuilder {
             (l, r) -> l + ":" + r,
             JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMinutes(5)),
             StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String()))
-        .to(output);
+        .to(output, org.apache.kafka.streams.kstream.Produced.with(Serdes.String(), Serdes.String()));
     return builder.build();
   }
 }

--- a/join-kstream-ktable/pom.xml
+++ b/join-kstream-ktable/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/join-kstream-ktable/src/main/java/io/example/kstreamspatterns/joinkstreamktable/TopologyBuilder.java
+++ b/join-kstream-ktable/src/main/java/io/example/kstreamspatterns/joinkstreamktable/TopologyBuilder.java
@@ -19,7 +19,9 @@ public final class TopologyBuilder {
         builder.stream(stream, Consumed.with(Serdes.String(), Serdes.String()));
     KTable<String, String> tableSource =
         builder.table(table, Consumed.with(Serdes.String(), Serdes.String()));
-    streamSource.join(tableSource, (s, t) -> s + ":" + t).to(output);
+    streamSource
+        .join(tableSource, (s, t) -> s + ":" + t)
+        .to(output, org.apache.kafka.streams.kstream.Produced.with(Serdes.String(), Serdes.String()));
     return builder.build();
   }
 }

--- a/join-ktable-ktable/pom.xml
+++ b/join-ktable-ktable/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/join-ktable-ktable/src/main/java/io/example/kstreamspatterns/joinktablektable/TopologyBuilder.java
+++ b/join-ktable-ktable/src/main/java/io/example/kstreamspatterns/joinktablektable/TopologyBuilder.java
@@ -16,7 +16,9 @@ public final class TopologyBuilder {
     StreamsBuilder builder = new StreamsBuilder();
     KTable<String, String> a = builder.table(tableA, Consumed.with(Serdes.String(), Serdes.String()));
     KTable<String, String> b = builder.table(tableB, Consumed.with(Serdes.String(), Serdes.String()));
-    a.join(b, (va, vb) -> va + ":" + vb).toStream().to(output);
+    a.join(b, (va, vb) -> va + ":" + vb)
+        .toStream()
+        .to(output, org.apache.kafka.streams.kstream.Produced.with(Serdes.String(), Serdes.String()));
     return builder.build();
   }
 }

--- a/late-early-data/pom.xml
+++ b/late-early-data/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/late-early-data/src/test/java/io/example/kstreamspatterns/lateearlydata/LateEarlyDataIT.java
+++ b/late-early-data/src/test/java/io/example/kstreamspatterns/lateearlydata/LateEarlyDataIT.java
@@ -58,7 +58,8 @@ public class LateEarlyDataIT extends KafkaIntegrationTest {
       consumer.subscribe(List.of("output-late-early-it"));
       ConsumerRecords<String, Long> records = consumer.poll(Duration.ofSeconds(10));
       List<Long> counts =
-          records.records("output-late-early-it").stream()
+          java.util.stream.StreamSupport
+              .stream(records.records("output-late-early-it").spliterator(), false)
               .filter(r -> r.key().startsWith("k@"))
               .map(ConsumerRecord::value)
               .collect(Collectors.toList());

--- a/materialized-views/pom.xml
+++ b/materialized-views/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/rekey-repartition/pom.xml
+++ b/rekey-repartition/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/rekey-repartition/src/main/java/io/example/kstreamspatterns/rekeyrepartition/TopologyBuilder.java
+++ b/rekey-repartition/src/main/java/io/example/kstreamspatterns/rekeyrepartition/TopologyBuilder.java
@@ -18,7 +18,7 @@ public final class TopologyBuilder {
         .selectKey((k, v) -> v.split(":")[0])
         .mapValues(v -> v.split(":")[1])
         .repartition(Repartitioned.with(Serdes.String(), Serdes.String()))
-        .to(output);
+        .to(output, org.apache.kafka.streams.kstream.Produced.with(Serdes.String(), Serdes.String()));
     return builder.build();
   }
 }

--- a/rekey-repartition/src/test/java/io/example/kstreamspatterns/rekeyrepartition/RekeyRepartitionIT.java
+++ b/rekey-repartition/src/test/java/io/example/kstreamspatterns/rekeyrepartition/RekeyRepartitionIT.java
@@ -53,7 +53,10 @@ public class RekeyRepartitionIT extends KafkaIntegrationTest {
     try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consProps)) {
       consumer.subscribe(Collections.singleton("output-rekey-it"));
       ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
-      assertThat(records.records("output-rekey-it").stream().map(ConsumerRecord::key))
+      assertThat(
+              java.util.stream.StreamSupport
+                  .stream(records.records("output-rekey-it").spliterator(), false)
+                  .map(ConsumerRecord::key))
           .containsExactlyInAnyOrder("u1", "u2");
     }
 

--- a/retry-dlq/pom.xml
+++ b/retry-dlq/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/stateless-transforms/pom.xml
+++ b/stateless-transforms/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/stateless-transforms/src/main/java/io/example/kstreamspatterns/statelesstransforms/TopologyBuilder.java
+++ b/stateless-transforms/src/main/java/io/example/kstreamspatterns/statelesstransforms/TopologyBuilder.java
@@ -3,6 +3,7 @@ package io.example.kstreamspatterns.statelesstransforms;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Produced;
 
 public final class TopologyBuilder {
   private TopologyBuilder() {}
@@ -17,7 +18,7 @@ public final class TopologyBuilder {
         .mapValues(v -> v == null ? null : v.toUpperCase())
         .filter((k, v) -> v != null && !v.startsWith("IGNORE"))
         .flatMapValues(v -> java.util.Arrays.asList(v.split(" ")))
-        .to(output);
+        .to(output, Produced.with(Serdes.String(), Serdes.String()));
     return builder.build();
   }
 }

--- a/stateless-transforms/src/test/java/io/example/kstreamspatterns/statelesstransforms/StatelessTransformsIT.java
+++ b/stateless-transforms/src/test/java/io/example/kstreamspatterns/statelesstransforms/StatelessTransformsIT.java
@@ -26,6 +26,8 @@ public class StatelessTransformsIT extends KafkaIntegrationTest {
     Properties props = new Properties();
     props.put(StreamsConfig.APPLICATION_ID_CONFIG, "stateless-it");
     props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
+    props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+    props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
 
     KafkaStreams streams = new KafkaStreams(TopologyBuilder.build(), props);
     streams.start();
@@ -48,7 +50,10 @@ public class StatelessTransformsIT extends KafkaIntegrationTest {
     try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consProps)) {
       consumer.subscribe(Collections.singleton("output-it"));
       ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
-      assertThat(records.records("output-it").stream().map(ConsumerRecord::value))
+      assertThat(
+              java.util.stream.StreamSupport
+                  .stream(records.records("output-it").spliterator(), false)
+                  .map(ConsumerRecord::value))
           .contains("HELLO", "WORLD");
     }
 

--- a/stateless-transforms/src/test/java/io/example/kstreamspatterns/statelesstransforms/TopologyBuilderTest.java
+++ b/stateless-transforms/src/test/java/io/example/kstreamspatterns/statelesstransforms/TopologyBuilderTest.java
@@ -12,7 +12,14 @@ import org.junit.jupiter.api.Test;
 public class TopologyBuilderTest {
   @Test
   void mapFilterFlatMap() {
-    try (TopologyTestDriver testDriver = new TopologyTestDriver(TopologyBuilder.build())) {
+    java.util.Properties props = new java.util.Properties();
+    props.put(
+        org.apache.kafka.streams.StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG,
+        Serdes.String().getClass().getName());
+    props.put(
+        org.apache.kafka.streams.StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG,
+        Serdes.String().getClass().getName());
+    try (TopologyTestDriver testDriver = new TopologyTestDriver(TopologyBuilder.build(), props)) {
       TestInputTopic<String, String> in =
           testDriver.createInputTopic("input-stateless", Serdes.String().serializer(), Serdes.String().serializer());
       TestOutputTopic<String, String> out =

--- a/suppression/pom.xml
+++ b/suppression/pom.xml
@@ -13,6 +13,9 @@
       <groupId>io.example</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/suppression/src/test/java/io/example/kstreamspatterns/suppression/SuppressionIT.java
+++ b/suppression/src/test/java/io/example/kstreamspatterns/suppression/SuppressionIT.java
@@ -64,7 +64,8 @@ public class SuppressionIT extends KafkaIntegrationTest {
       consumer.subscribe(List.of("output-suppression-it"));
       ConsumerRecords<String, Long> records = consumer.poll(Duration.ofSeconds(10));
       List<Long> values =
-          records.records("output-suppression-it").stream()
+          java.util.stream.StreamSupport
+              .stream(records.records("output-suppression-it").spliterator(), false)
               .map(ConsumerRecord::value)
               .collect(Collectors.toList());
       assertThat(values).containsExactly(2L);


### PR DESCRIPTION
## Summary
- produce a test-jar from the `common` module
- depend on the `common` test-jar with `test` scope across module POMs
- replace direct `stream()` calls on `ConsumerRecords#records` with `StreamSupport.stream` in integration tests for compatibility
- specify String SerDes for sink topics across topologies so Kafka Streams doesn't require default configs
- configure default String SerDes in stateless transforms tests to prevent missing serde `ConfigException`

## Testing
- `mvn -q -DskipITs=false test` *(fails: Plugin org.apache.maven.plugins:maven-failsafe-plugin:3.2.5 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897871f10ac83298c2b4d715c298209