### PR TITLE
Ensure KTable populated before order in IT

### DIFF
--- a/enrichment-ktable/src/test/java/io/example/kstreamspatterns/enrichmentktable/EnrichmentKTableIT.java
+++ b/enrichment-ktable/src/test/java/io/example/kstreamspatterns/enrichmentktable/EnrichmentKTableIT.java
@@ -37,6 +37,13 @@ public class EnrichmentKTableIT extends KafkaIntegrationTest {
     prodProps.put("value.serializer", Serdes.String().serializer().getClass().getName());
     try (KafkaProducer<String, String> producer = new KafkaProducer<>(prodProps)) {
       producer.send(new ProducerRecord<>("products-it", "p1", "apple"));
+      producer.flush();
+      // Give the product stream time to populate the KTable before sending the order.
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
       producer.send(new ProducerRecord<>("orders-it", "p1", "5"));
       producer.flush();
     }


### PR DESCRIPTION
## Summary
- Avoid race in KTable enrichment test by flushing the product publish and pausing before the order is sent

## Testing
- `mvn -q -pl enrichment-ktable -am test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-failsafe-plugin:pom:3.2.5 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897a12e15948329940b516fe0ef7758