### PR TITLE
Ensure KTable populated before order in IT

### DIFF
--- a/enrichment-ktable/src/test/java/io/example/kstreamspatterns/enrichmentktable/EnrichmentKTableIT.java
+++ b/enrichment-ktable/src/test/java/io/example/kstreamspatterns/enrichmentktable/EnrichmentKTableIT.java
@@ -4,10 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.example.kstreamspatterns.common.KafkaIntegrationTest;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -23,20 +24,29 @@ public class EnrichmentKTableIT extends KafkaIntegrationTest {
     System.setProperty("orders.topic", "orders-it");
     System.setProperty("products.topic", "products-it");
     System.setProperty("output.topic", "enriched-orders-it");
-
-    Properties props = new Properties();
-    props.put(StreamsConfig.APPLICATION_ID_CONFIG, "enrich-it");
-    props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
-
-    KafkaStreams streams = new KafkaStreams(TopologyBuilder.build(), props);
-    streams.start();
-
     Properties prodProps = new Properties();
     prodProps.put("bootstrap.servers", bootstrapServers());
     prodProps.put("key.serializer", Serdes.String().serializer().getClass().getName());
     prodProps.put("value.serializer", Serdes.String().serializer().getClass().getName());
     try (KafkaProducer<String, String> producer = new KafkaProducer<>(prodProps)) {
       producer.send(new ProducerRecord<>("products-it", "p1", "apple"));
+      producer.flush();
+    }
+
+    Properties props = new Properties();
+    props.put(StreamsConfig.APPLICATION_ID_CONFIG, "enrich-it");
+    props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    // Disable caching and shorten commit interval so the KTable is updated immediately
+    props.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+    props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
+
+    KafkaStreams streams = new KafkaStreams(TopologyBuilder.build(), props);
+    streams.cleanUp();
+    streams.start();
+    waitForRunning(streams);
+
+    try (KafkaProducer<String, String> producer = new KafkaProducer<>(prodProps)) {
       producer.send(new ProducerRecord<>("orders-it", "p1", "5"));
       producer.flush();
     }
@@ -53,14 +63,28 @@ public class EnrichmentKTableIT extends KafkaIntegrationTest {
         Serdes.String().deserializer().getClass());
     try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consProps)) {
       consumer.subscribe(Collections.singleton("enriched-orders-it"));
-      ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
-      assertThat(
-              java.util.stream.StreamSupport
-                  .stream(records.records("enriched-orders-it").spliterator(), false)
-                  .map(ConsumerRecord::value))
-          .contains("apple:5");
+      List<String> values = new ArrayList<>();
+      long deadline = System.currentTimeMillis() + 10_000;
+      while (values.isEmpty() && System.currentTimeMillis() < deadline) {
+        ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
+        records.records("enriched-orders-it").forEach(r -> values.add(r.value()));
+      }
+      assertThat(values).contains("apple:5");
     }
 
     streams.close();
+  }
+
+  private static void waitForRunning(KafkaStreams streams) {
+    long deadline = System.currentTimeMillis() + 10_000;
+    while (streams.state() != KafkaStreams.State.RUNNING
+        && System.currentTimeMillis() < deadline) {
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        break;
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Publish the product record before starting Kafka Streams so the KTable is fully populated when orders arrive
- Start Streams and then send the order, using a consumer to poll for the enriched output

## Testing
- `mvn -q -pl enrichment-ktable -am test` *(fails: Plugin org.apache.maven.plugins:maven-failsafe-plugin:3.2.5 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-failsafe-plugin:pom:3.2.5 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897a12e15948329940b516fe0ef7758