### PR TITLE
Ensure KTable populated before order in IT

### DIFF
--- a/enrichment-ktable/src/main/java/io/example/kstreamspatterns/enrichmentktable/TopologyBuilder.java
+++ b/enrichment-ktable/src/main/java/io/example/kstreamspatterns/enrichmentktable/TopologyBuilder.java
@@ -1,11 +1,14 @@
 package io.example.kstreamspatterns.enrichmentktable;
 
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.Materialized;
 
 public final class TopologyBuilder {
   private TopologyBuilder() {}
@@ -18,7 +21,10 @@ public final class TopologyBuilder {
     KStream<String, String> orderStream =
         builder.stream(orders, Consumed.with(Serdes.String(), Serdes.String()));
     KTable<String, String> productTable =
-        builder.table(products, Consumed.with(Serdes.String(), Serdes.String()));
+        builder.table(
+            products,
+            Consumed.with(Serdes.String(), Serdes.String()),
+            Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("product-store"));
     orderStream
         .leftJoin(
             productTable,

--- a/enrichment-ktable/src/test/java/io/example/kstreamspatterns/enrichmentktable/EnrichmentKTableIT.java
+++ b/enrichment-ktable/src/test/java/io/example/kstreamspatterns/enrichmentktable/EnrichmentKTableIT.java
@@ -4,22 +4,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.example.kstreamspatterns.common.KafkaIntegrationTest;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.junit.jupiter.api.Test;
 
 public class EnrichmentKTableIT extends KafkaIntegrationTest {
   @Test
-  void endToEndEnrichment() {
+  void endToEndEnrichment() throws Exception {
     System.setProperty("orders.topic", "orders-it");
     System.setProperty("products.topic", "products-it");
     System.setProperty("output.topic", "enriched-orders-it");
@@ -27,18 +31,35 @@ public class EnrichmentKTableIT extends KafkaIntegrationTest {
     Properties props = new Properties();
     props.put(StreamsConfig.APPLICATION_ID_CONFIG, "enrich-it");
     props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    // Disable caching and shorten commit interval so the KTable is updated immediately
+    props.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+    props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
 
     KafkaStreams streams = new KafkaStreams(TopologyBuilder.build(), props);
+    streams.cleanUp();
     streams.start();
+    waitForRunning(streams);
 
     Properties prodProps = new Properties();
     prodProps.put("bootstrap.servers", bootstrapServers());
     prodProps.put("key.serializer", Serdes.String().serializer().getClass().getName());
     prodProps.put("value.serializer", Serdes.String().serializer().getClass().getName());
     try (KafkaProducer<String, String> producer = new KafkaProducer<>(prodProps)) {
-      producer.send(new ProducerRecord<>("products-it", "p1", "apple"));
-      producer.send(new ProducerRecord<>("orders-it", "p1", "5"));
-      producer.flush();
+      producer.send(new ProducerRecord<>("products-it", "p1", "apple")).get();
+    }
+
+    ReadOnlyKeyValueStore<String, String> store =
+        streams.store(
+            StoreQueryParameters.fromNameAndType(
+                "product-store", QueryableStoreTypes.keyValueStore()));
+    long waitUntil = System.currentTimeMillis() + 10_000;
+    while (store.get("p1") == null && System.currentTimeMillis() < waitUntil) {
+      Thread.sleep(100);
+    }
+
+    try (KafkaProducer<String, String> producer = new KafkaProducer<>(prodProps)) {
+      producer.send(new ProducerRecord<>("orders-it", "p1", "5")).get();
     }
 
     Properties consProps = new Properties();
@@ -53,14 +74,28 @@ public class EnrichmentKTableIT extends KafkaIntegrationTest {
         Serdes.String().deserializer().getClass());
     try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consProps)) {
       consumer.subscribe(Collections.singleton("enriched-orders-it"));
-      ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
-      assertThat(
-              java.util.stream.StreamSupport
-                  .stream(records.records("enriched-orders-it").spliterator(), false)
-                  .map(ConsumerRecord::value))
-          .contains("apple:5");
+      List<String> values = new ArrayList<>();
+      long deadline = System.currentTimeMillis() + 10_000;
+      while (values.isEmpty() && System.currentTimeMillis() < deadline) {
+        ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
+        records.records("enriched-orders-it").forEach(r -> values.add(r.value()));
+      }
+      assertThat(values).contains("apple:5");
     }
 
     streams.close();
+  }
+
+  private static void waitForRunning(KafkaStreams streams) {
+    long deadline = System.currentTimeMillis() + 10_000;
+    while (streams.state() != KafkaStreams.State.RUNNING
+        && System.currentTimeMillis() < deadline) {
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        break;
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Materialize the products KTable store so tests can verify it is restored
- In integration test, wait until the product store contains the record before sending the order and polling for enriched output

## Testing
- `mvn -q -pl enrichment-ktable -am test` *(fails: Plugin org.apache.maven.plugins:maven-failsafe-plugin:3.2.5 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-failsafe-plugin:pom:3.2.5 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897a12e15948329940b516fe0ef7758