### PR TITLE
docs: add build instructions for pattern modules

### DIFF
--- a/agg-window-hopping/README.md
+++ b/agg-window-hopping/README.md
@@ -9,8 +9,12 @@ input --> groupByKey --> window(1m,30s).count --> output
 ## How to run
 
 ```bash
-docker compose up -d
-./agg-window-hopping/run.sh
+mvn -pl agg-window-hopping -am clean package
+java -jar agg-window-hopping/target/agg-window-hopping-1.0.0-SNAPSHOT.jar \
+  -Dbootstrap.servers=localhost:9092 \
+  -Dapplication.id=agg-window-hopping \
+  -Dinput.topic=input \
+  -Doutput.topic=hopping-count
 ```
 
 Produce records on `input` and observe counts on `hopping-count`.

--- a/agg-window-session/README.md
+++ b/agg-window-session/README.md
@@ -9,8 +9,12 @@ input --> groupByKey --> sessionWindow(1m).count --> output
 ## How to run
 
 ```bash
-docker compose up -d
-./agg-window-session/run.sh
+mvn -pl agg-window-session -am clean package
+java -jar agg-window-session/target/agg-window-session-1.0.0-SNAPSHOT.jar \
+  -Dbootstrap.servers=localhost:9092 \
+  -Dapplication.id=agg-window-session \
+  -Dinput.topic=session-input \
+  -Doutput.topic=session-output
 ```
 
-Produce records on `input` and observe counts on `session-count`.
+Produce records on `session-input` and observe counts on `session-output`.

--- a/agg-window-tumbling/README.md
+++ b/agg-window-tumbling/README.md
@@ -9,8 +9,12 @@ input --> groupByKey --> window(1m).count --> output
 ## How to run
 
 ```bash
-docker compose up -d
-./agg-window-tumbling/run.sh
+mvn -pl agg-window-tumbling -am clean package
+java -jar agg-window-tumbling/target/agg-window-tumbling-1.0.0-SNAPSHOT.jar \
+  -Dbootstrap.servers=localhost:9092 \
+  -Dapplication.id=agg-window-tumbling \
+  -Dinput.topic=tumbling-input \
+  -Doutput.topic=tumbling-output
 ```
 
-Produce records on `input` and observe counts on `tumbling-count`.
+Produce records on `tumbling-input` and observe counts on `tumbling-output`.

--- a/branch-route/README.md
+++ b/branch-route/README.md
@@ -11,8 +11,13 @@ input-branch ---> branch ---+--> even-branch
 ## How to run
 
 ```bash
-docker compose up -d
-./branch-route/run.sh
+mvn -pl branch-route -am clean package
+java -jar branch-route/target/branch-route-1.0.0-SNAPSHOT.jar \
+  -Dbootstrap.servers=localhost:9092 \
+  -Dapplication.id=branch-route \
+  -Dinput.topic=input-branch \
+  -Deven.topic=even-branch \
+  -Dodd.topic=odd-branch
 ```
 
 Produces numbers to `input-branch` and observe routed values on `even-branch` and `odd-branch`.

--- a/common/README.md
+++ b/common/README.md
@@ -1,0 +1,19 @@
+# Common Utilities
+
+Shared classes and helpers used across the Kafka Streams pattern modules.
+
+## Build and Install
+
+```bash
+mvn -pl common -am clean install
+```
+
+This compiles the module and installs it to your local Maven repository so other modules can depend on it.
+
+## Run Tests
+
+```bash
+mvn -pl common -am test
+```
+
+The common module does not produce a runnable JAR by itself. It is consumed by the other example modules in this repository.

--- a/deduplication/README.md
+++ b/deduplication/README.md
@@ -11,5 +11,10 @@ input-dedup --> [deduplicate by key] --> output-dedup
 ## Running
 
 ```bash
-./run.sh
+mvn -pl deduplication -am clean package
+java -jar deduplication/target/deduplication-1.0.0-SNAPSHOT.jar \
+  -Dbootstrap.servers=localhost:9092 \
+  -Dapplication.id=deduplication \
+  -Dinput.topic=input-dedup \
+  -Doutput.topic=output-dedup
 ```

--- a/join-kstream-kstream/README.md
+++ b/join-kstream-kstream/README.md
@@ -11,8 +11,13 @@ right-join ---/
 ## How to run
 
 ```bash
-docker compose up -d
-./join-kstream-kstream/run.sh
+mvn -pl join-kstream-kstream -am clean package
+java -jar join-kstream-kstream/target/join-kstream-kstream-1.0.0-SNAPSHOT.jar \
+  -Dbootstrap.servers=localhost:9092 \
+  -Dapplication.id=join-kstream-kstream \
+  -Dleft.topic=left-join \
+  -Dright.topic=right-join \
+  -Doutput.topic=joined
 ```
 
-Produces matching records on `left-join` and `right-join` and observe joined values on `joined`.
+Produce matching records on `left-join` and `right-join` and observe joined values on `joined`.

--- a/join-kstream-ktable/README.md
+++ b/join-kstream-ktable/README.md
@@ -11,8 +11,13 @@ table-join --/
 ## How to run
 
 ```bash
-docker compose up -d
-./join-kstream-ktable/run.sh
+mvn -pl join-kstream-ktable -am clean package
+java -jar join-kstream-ktable/target/join-kstream-ktable-1.0.0-SNAPSHOT.jar \
+  -Dbootstrap.servers=localhost:9092 \
+  -Dapplication.id=join-kstream-ktable \
+  -Dstream.topic=stream \
+  -Dtable.topic=table \
+  -Doutput.topic=joined
 ```
 
-Produce records on `table-join` and `stream-join` and observe joined values on `joined`.
+Produce records on `stream` and `table` and observe joined values on `joined`.

--- a/join-ktable-ktable/README.md
+++ b/join-ktable-ktable/README.md
@@ -11,8 +11,13 @@ table-a ---\
 ## How to run
 
 ```bash
-docker compose up -d
-./join-ktable-ktable/run.sh
+mvn -pl join-ktable-ktable -am clean package
+java -jar join-ktable-ktable/target/join-ktable-ktable-1.0.0-SNAPSHOT.jar \
+  -Dbootstrap.servers=localhost:9092 \
+  -Dapplication.id=join-ktable-ktable \
+  -Dleft.table.topic=left-table \
+  -Dright.table.topic=right-table \
+  -Doutput.topic=joined-table
 ```
 
-Produce records on `table-a` and `table-b` and observe joined values on `joined`.
+Produce records on `left-table` and `right-table` and observe joined values on `joined-table`.

--- a/late-early-data/README.md
+++ b/late-early-data/README.md
@@ -9,8 +9,11 @@ input --> groupByKey --> window(5s, grace 5s).count.suppress --> output
 ## How to run
 
 ```bash
-docker compose up -d
-./late-early-data/run.sh
+mvn -pl late-early-data -am clean package
+java -jar late-early-data/target/late-early-data-1.0.0-SNAPSHOT.jar \
+  -Dinput.topic=late-early-input \
+  -Dearly.topic=late-early-early \
+  -Doutput.topic=late-early-output
 ```
 
 Produce records on `late-early-input` and observe early and final counts on `late-early-output`.

--- a/materialized-views/README.md
+++ b/materialized-views/README.md
@@ -8,8 +8,15 @@ Expose a materialized key-value store via a simple REST endpoint for interactive
 input-materialized --> [groupBy/count -> materialized store] --> output-materialized
 ```
 
-## Running
+## How to run
 
 ```bash
-./run.sh
+mvn -pl materialized-views -am clean package
+java -jar materialized-views/target/materialized-views-1.0.0-SNAPSHOT.jar \
+  -Dbootstrap.servers=localhost:9092 \
+  -Dapplication.id=materialized-views \
+  -Dinput.topic=input-materialized \
+  -Doutput.topic=output-materialized \
+  -Dcounts.store=counts-store \
+  -Dvalues.store=values-store
 ```

--- a/retry-dlq/README.md
+++ b/retry-dlq/README.md
@@ -10,8 +10,16 @@ input/retry-1/retry-2 -> [RetryProcessor] -> success
                                  \-> dlq
 ```
 
-### Running
+## How to run
 
-```
-./run.sh
+```bash
+mvn -pl retry-dlq -am clean package
+java -jar retry-dlq/target/retry-dlq-1.0.0-SNAPSHOT.jar \
+  -Dbootstrap.servers=localhost:9092 \
+  -Dapplication.id=retry-dlq-app \
+  -Dinput.topic=input-retry \
+  -Dretry1.topic=retry-1 \
+  -Dretry2.topic=retry-2 \
+  -Ddlq.topic=dlq \
+  -Doutput.topic=output-retry
 ```

--- a/suppression/README.md
+++ b/suppression/README.md
@@ -8,8 +8,13 @@ Emit final windowed results only using `Suppressed.untilWindowCloses`.
 input-suppression --> [group & count in tumbling window] --> suppress until window closes --> output-suppression
 ```
 
-## Running
+## How to run
 
 ```bash
-./run.sh
+mvn -pl suppression -am clean package
+java -jar suppression/target/suppression-1.0.0-SNAPSHOT.jar \
+  -Dbootstrap.servers=localhost:9092 \
+  -Dapplication.id=suppression \
+  -Dinput.topic=input-suppression \
+  -Doutput.topic=output-suppression
 ```


### PR DESCRIPTION
## Summary
- expand pattern module READMEs with explicit Maven build and `java -jar` run commands
- document how to run branch, join, window, deduplication, suppression, materialized view, retry/DLQ, and late/early modules

## Testing
- `mvn -q -pl branch-route -am test` *(fails: Plugin org.apache.maven.plugins:maven-failsafe-plugin:3.2.5 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689818dd05148329ae1f65baa4d7a491