### PR TITLE
docs: add fake data generator notes to modules

### DIFF
--- a/agg-window-hopping/README.md
+++ b/agg-window-hopping/README.md
@@ -26,3 +26,11 @@ java -jar agg-window-hopping/target/agg-window-hopping-1.0.0-SNAPSHOT.jar \
 ```
 
 Produce records on `input` and observe counts on `hopping-count`.
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator agg-window-hopping
+```

--- a/agg-window-session/README.md
+++ b/agg-window-session/README.md
@@ -25,3 +25,11 @@ java -jar agg-window-session/target/agg-window-session-1.0.0-SNAPSHOT.jar \
 ```
 
 Produce records on `session-input` and observe counts on `session-output`.
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator agg-window-session
+```

--- a/agg-window-tumbling/README.md
+++ b/agg-window-tumbling/README.md
@@ -25,3 +25,11 @@ java -jar agg-window-tumbling/target/agg-window-tumbling-1.0.0-SNAPSHOT.jar \
 ```
 
 Produce records on `tumbling-input` and observe counts on `tumbling-output`.
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator agg-window-tumbling
+```

--- a/aggregate-reduce-count/README.md
+++ b/aggregate-reduce-count/README.md
@@ -28,3 +28,11 @@ java -jar aggregate-reduce-count/target/aggregate-reduce-count-1.0.0-SNAPSHOT.ja
   -Dmax.topic=max-arc \
   -Dcount.topic=count-arc
 ```
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator aggregate-reduce-count
+```

--- a/branch-route/README.md
+++ b/branch-route/README.md
@@ -29,3 +29,11 @@ java -jar branch-route/target/branch-route-1.0.0-SNAPSHOT.jar \
 ```
 
 Produces numbers to `input-branch` and observe routed values on `even-branch` and `odd-branch`.
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator branch-route
+```

--- a/deduplication/README.md
+++ b/deduplication/README.md
@@ -25,3 +25,11 @@ java -jar deduplication/target/deduplication-1.0.0-SNAPSHOT.jar \
   -Dinput.topic=input-dedup \
   -Doutput.topic=output-dedup
 ```
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator deduplication
+```

--- a/enrichment-globalktable/README.md
+++ b/enrichment-globalktable/README.md
@@ -26,3 +26,11 @@ java -jar enrichment-globalktable/target/enrichment-globalktable-1.0.0-SNAPSHOT.
   -Dproducts.topic=products \
   -Doutput.topic=enriched-orders
 ```
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator enrichment-globalktable
+```

--- a/enrichment-ktable/README.md
+++ b/enrichment-ktable/README.md
@@ -26,3 +26,11 @@ java -jar enrichment-ktable/target/enrichment-ktable-1.0.0-SNAPSHOT.jar \
   -Dproducts.topic=products \
   -Doutput.topic=enriched-orders
 ```
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator enrichment-ktable
+```

--- a/exactly-once-outbox/README.md
+++ b/exactly-once-outbox/README.md
@@ -25,3 +25,11 @@ java -jar exactly-once-outbox/target/exactly-once-outbox-1.0.0-SNAPSHOT.jar \
   -Dprocessed.topic=processed-orders \
   -Doutbox.topic=orders-outbox
 ```
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator exactly-once-outbox
+```

--- a/fanout-fanin/README.md
+++ b/fanout-fanin/README.md
@@ -30,3 +30,11 @@ java -jar fanout-fanin/target/fanout-fanin-1.0.0-SNAPSHOT.jar \
   -Dinput.topic=fanout-input \
   -Doutput.topic=fanout-output
 ```
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator fanout-fanin
+```

--- a/join-kstream-kstream/README.md
+++ b/join-kstream-kstream/README.md
@@ -28,3 +28,11 @@ java -jar join-kstream-kstream/target/join-kstream-kstream-1.0.0-SNAPSHOT.jar \
 ```
 
 Produce matching records on `left-join` and `right-join` and observe joined values on `joined`.
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator join-kstream-kstream
+```

--- a/join-kstream-ktable/README.md
+++ b/join-kstream-ktable/README.md
@@ -28,3 +28,11 @@ java -jar join-kstream-ktable/target/join-kstream-ktable-1.0.0-SNAPSHOT.jar \
 ```
 
 Produce records on `stream` and `table` and observe joined values on `joined`.
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator join-kstream-ktable
+```

--- a/join-ktable-ktable/README.md
+++ b/join-ktable-ktable/README.md
@@ -29,3 +29,11 @@ java -jar join-ktable-ktable/target/join-ktable-ktable-1.0.0-SNAPSHOT.jar \
 ```
 
 Produce records on `left-table` and `right-table` and observe joined values on `joined-table`.
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator join-ktable-ktable
+```

--- a/late-early-data/README.md
+++ b/late-early-data/README.md
@@ -25,3 +25,11 @@ java -jar late-early-data/target/late-early-data-1.0.0-SNAPSHOT.jar \
 ```
 
 Produce records on `late-early-input` and observe early and final counts on `late-early-output`.
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator late-early-data
+```

--- a/materialized-views/README.md
+++ b/materialized-views/README.md
@@ -27,3 +27,11 @@ java -jar materialized-views/target/materialized-views-1.0.0-SNAPSHOT.jar \
   -Dcounts.store=counts-store \
   -Dvalues.store=values-store
 ```
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator materialized-views
+```

--- a/rekey-repartition/README.md
+++ b/rekey-repartition/README.md
@@ -23,3 +23,11 @@ java -jar rekey-repartition/target/rekey-repartition-1.0.0-SNAPSHOT.jar \
   -Dinput.topic=input-rekey \
   -Doutput.topic=output-rekey
 ```
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator rekey-repartition
+```

--- a/retry-dlq/README.md
+++ b/retry-dlq/README.md
@@ -30,3 +30,11 @@ java -jar retry-dlq/target/retry-dlq-1.0.0-SNAPSHOT.jar \
   -Ddlq.topic=dlq \
   -Doutput.topic=output-retry
 ```
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator retry-dlq
+```

--- a/stateless-transforms/README.md
+++ b/stateless-transforms/README.md
@@ -24,3 +24,11 @@ java -jar stateless-transforms/target/stateless-transforms-1.0.0-SNAPSHOT.jar \
   -Dinput.topic=input-stateless \
   -Doutput.topic=output-stateless
 ```
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator stateless-transforms
+```

--- a/suppression/README.md
+++ b/suppression/README.md
@@ -26,3 +26,11 @@ java -jar suppression/target/suppression-1.0.0-SNAPSHOT.jar \
   -Dinput.topic=input-suppression \
   -Doutput.topic=output-suppression
 ```
+
+## Generate example data
+
+```bash
+mvn -pl common -am package
+java -cp common/target/common-1.0.0-SNAPSHOT.jar \
+  com.fattahpour.kstreamspatterns.common.FakeDataGenerator suppression
+```


### PR DESCRIPTION
## Summary
- remove standalone fake data guide
- document fake data generator usage in each module's README

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-failsafe-plugin:pom:3.2.5 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689832f69d8c8329b7a67ea46b702817