### PR TITLE
Add modern responsive login page

### DIFF
--- a/login.html
+++ b/login.html
@@ -1,0 +1,464 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sign in</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --font-family: "Inter", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      --color-text: #101828;
+      --color-text-muted: #475467;
+      --color-card-bg: rgba(255, 255, 255, 0.72);
+      --color-card-border: rgba(15, 23, 42, 0.08);
+      --color-input-bg: rgba(255, 255, 255, 0.9);
+      --color-input-border: rgba(15, 23, 42, 0.15);
+      --color-input-focus: rgba(99, 102, 241, 0.35);
+      --color-error: #d92d20;
+      --color-button-bg: #6366f1;
+      --color-button-bg-hover: #4f46e5;
+      --color-button-text: #ffffff;
+      --color-link: #4f46e5;
+      --color-checkbox-bg: rgba(99, 102, 241, 0.15);
+      --shadow-elevated: 0 20px 45px rgba(15, 23, 42, 0.12);
+      --radius-xl: 24px;
+      --transition-base: 200ms ease;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --color-text: #f8fafc;
+        --color-text-muted: #cbd5f5;
+        --color-card-bg: rgba(15, 23, 42, 0.55);
+        --color-card-border: rgba(148, 163, 184, 0.15);
+        --color-input-bg: rgba(15, 23, 42, 0.35);
+        --color-input-border: rgba(148, 163, 184, 0.25);
+        --color-input-focus: rgba(99, 102, 241, 0.6);
+        --color-error: #ff8da1;
+        --color-button-bg: rgba(99, 102, 241, 0.9);
+        --color-button-bg-hover: rgba(129, 140, 248, 1);
+        --color-link: #c7d2fe;
+        --color-checkbox-bg: rgba(99, 102, 241, 0.3);
+        --shadow-elevated: 0 24px 60px rgba(2, 6, 23, 0.45);
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html, body {
+      height: 100%;
+    }
+
+    body.login {
+      margin: 0;
+      font-family: var(--font-family);
+      color: var(--color-text);
+      background-image: linear-gradient(135deg, rgba(17, 25, 40, 0.6) 0%, rgba(17, 24, 39, 0.4) 100%), url("https://example.com/hero.jpg");
+      background-size: cover;
+      background-attachment: fixed;
+      background-position: center;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2.5rem 1.5rem;
+    }
+
+    .login__main {
+      width: 100%;
+      display: flex;
+      justify-content: center;
+    }
+
+    .login-card {
+      width: min(100%, 420px);
+      background: var(--color-card-bg);
+      backdrop-filter: blur(18px);
+      border: 1px solid var(--color-card-border);
+      border-radius: var(--radius-xl);
+      box-shadow: var(--shadow-elevated);
+      padding: 2.5rem 2.25rem 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 2rem;
+    }
+
+    .login-card__header {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .login-card__brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-weight: 600;
+      font-size: 1rem;
+      color: var(--color-text);
+    }
+
+    .login-card__logo {
+      width: 42px;
+      height: 42px;
+      border-radius: 50%;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: linear-gradient(135deg, rgba(99, 102, 241, 0.85), rgba(79, 70, 229, 0.95));
+      color: #fff;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .login-card__brand-name {
+      letter-spacing: 0.05em;
+    }
+
+    .login-card__title {
+      margin: 0;
+      font-size: clamp(1.8rem, 3vw, 2.2rem);
+      font-weight: 700;
+      color: var(--color-text);
+    }
+
+    .login-card__subtitle {
+      margin: 0;
+      color: var(--color-text-muted);
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+
+    .login-form {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    .login-form__group {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .login-form__label {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--color-text);
+    }
+
+    .login-form__input-wrapper {
+      position: relative;
+      display: flex;
+      align-items: center;
+    }
+
+    .login-form__input {
+      width: 100%;
+      padding: 0.875rem 1rem;
+      border-radius: 14px;
+      border: 1px solid var(--color-input-border);
+      background-color: var(--color-input-bg);
+      color: var(--color-text);
+      font-size: 1rem;
+      transition: border-color var(--transition-base), box-shadow var(--transition-base), background-color var(--transition-base);
+    }
+
+    .login-form__input::placeholder {
+      color: rgba(71, 84, 103, 0.6);
+    }
+
+    .login-form__input:focus-visible {
+      outline: none;
+      border-color: var(--color-input-focus);
+      box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-input-focus) 45%, transparent);
+      background-color: color-mix(in srgb, var(--color-input-bg) 70%, #ffffff 30%);
+    }
+
+    .login-form__input[aria-invalid="true"] {
+      border-color: var(--color-error);
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-error) 25%, transparent);
+    }
+
+    .login-form__toggle {
+      position: absolute;
+      top: 50%;
+      right: 0.75rem;
+      transform: translateY(-50%);
+      background: transparent;
+      border: none;
+      color: var(--color-link);
+      font-weight: 600;
+      font-size: 0.9rem;
+      cursor: pointer;
+      padding: 0.25rem 0.5rem;
+      border-radius: 999px;
+      transition: background-color var(--transition-base), color var(--transition-base);
+    }
+
+    .login-form__toggle:hover,
+    .login-form__toggle:focus-visible {
+      outline: none;
+      background-color: color-mix(in srgb, var(--color-checkbox-bg) 60%, transparent);
+      color: var(--color-button-bg);
+    }
+
+    .login-form__error {
+      min-height: 1.25rem;
+      font-size: 0.8rem;
+      color: var(--color-error);
+      line-height: 1.4;
+    }
+
+    .login-form__options {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      font-size: 0.9rem;
+    }
+
+    .login-form__checkbox {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      cursor: pointer;
+      user-select: none;
+      color: var(--color-text-muted);
+    }
+
+    .login-form__checkbox-input {
+      appearance: none;
+      -webkit-appearance: none;
+      width: 18px;
+      height: 18px;
+      border: 1.5px solid var(--color-input-border);
+      border-radius: 6px;
+      background-color: transparent;
+      display: grid;
+      place-content: center;
+      transition: border-color var(--transition-base), background-color var(--transition-base), box-shadow var(--transition-base);
+    }
+
+    .login-form__checkbox-input::before {
+      content: "";
+      width: 10px;
+      height: 10px;
+      border-radius: 3px;
+      transform: scale(0);
+      transition: transform var(--transition-base);
+      background-color: var(--color-button-bg);
+    }
+
+    .login-form__checkbox-input:checked {
+      border-color: var(--color-button-bg);
+      background-color: var(--color-checkbox-bg);
+    }
+
+    .login-form__checkbox-input:checked::before {
+      transform: scale(1);
+    }
+
+    .login-form__checkbox-input:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-input-focus) 45%, transparent);
+    }
+
+    .login-form__link,
+    .login-card__footer-link {
+      color: var(--color-link);
+      text-decoration: none;
+      font-weight: 600;
+      transition: color var(--transition-base);
+    }
+
+    .login-form__link:hover,
+    .login-form__link:focus-visible,
+    .login-card__footer-link:hover,
+    .login-card__footer-link:focus-visible {
+      outline: none;
+      color: var(--color-button-bg-hover);
+      text-decoration: underline;
+    }
+
+    .login-form__submit {
+      border: none;
+      border-radius: 16px;
+      padding: 0.9rem 1rem;
+      font-size: 1rem;
+      font-weight: 600;
+      background: var(--color-button-bg);
+      color: var(--color-button-text);
+      cursor: pointer;
+      transition: transform var(--transition-base), box-shadow var(--transition-base), background-color var(--transition-base);
+      box-shadow: 0 18px 30px rgba(79, 70, 229, 0.25);
+    }
+
+    .login-form__submit:hover {
+      background: var(--color-button-bg-hover);
+      transform: translateY(-1px);
+    }
+
+    .login-form__submit:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-button-bg) 35%, transparent);
+    }
+
+    .login-card__footer {
+      margin: 0;
+      font-size: 0.9rem;
+      color: var(--color-text-muted);
+      text-align: center;
+    }
+
+    .login-form__status {
+      margin: -0.5rem 0 0;
+      min-height: 1.25rem;
+      font-size: 0.85rem;
+      color: var(--color-text-muted);
+      text-align: center;
+    }
+
+    @media (min-width: 768px) {
+      body.login {
+        padding: 4rem;
+      }
+
+      .login-card {
+        padding: 3rem 3rem 2.5rem;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        transition-duration: 0.001ms !important;
+        animation-duration: 0.001ms !important;
+      }
+    }
+  </style>
+</head>
+<body class="login">
+  <main class="login__main">
+    <section class="login-card" aria-labelledby="login-title">
+      <header class="login-card__header">
+        <div class="login-card__brand" aria-label="Aurora UI">
+          <span class="login-card__logo" aria-hidden="true">AU</span>
+          <span class="login-card__brand-name">Aurora UI</span>
+        </div>
+        <h1 class="login-card__title" id="login-title">Welcome back</h1>
+        <p class="login-card__subtitle">We're glad to see you again. Sign in to stay connected with your dashboard.</p>
+      </header>
+      <form class="login-form" id="login-form" novalidate>
+        <div class="login-form__group">
+          <label class="login-form__label" for="email">Email address</label>
+          <input class="login-form__input" id="email" name="email" type="email" autocomplete="email" required placeholder="you@example.com" aria-describedby="email-error" />
+          <span class="login-form__error" id="email-error" aria-live="polite"></span>
+        </div>
+        <div class="login-form__group login-form__group--password">
+          <label class="login-form__label" for="password">Password</label>
+          <div class="login-form__input-wrapper">
+            <input class="login-form__input" id="password" name="password" type="password" autocomplete="current-password" required minlength="8" placeholder="Enter your password" aria-describedby="password-error" />
+            <button class="login-form__toggle" type="button" aria-controls="password" aria-pressed="false">Show</button>
+          </div>
+          <span class="login-form__error" id="password-error" aria-live="polite"></span>
+        </div>
+        <div class="login-form__options">
+          <label class="login-form__checkbox">
+            <input class="login-form__checkbox-input" type="checkbox" name="remember" id="remember" />
+            <span class="login-form__checkbox-label">Remember me</span>
+          </label>
+          <a class="login-form__link" href="#">Forgot password?</a>
+        </div>
+        <button class="login-form__submit" type="submit">Sign in</button>
+        <p class="login-form__status" id="login-status" role="status" aria-live="polite"></p>
+      </form>
+      <p class="login-card__footer">No account? <a class="login-card__footer-link" href="#">Sign up</a></p>
+    </section>
+  </main>
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      const form = document.getElementById("login-form");
+      const emailInput = document.getElementById("email");
+      const passwordInput = document.getElementById("password");
+      const emailError = document.getElementById("email-error");
+      const passwordError = document.getElementById("password-error");
+      const statusMessage = document.getElementById("login-status");
+      const toggleButton = document.querySelector(".login-form__toggle");
+
+      const validators = {
+        email(value) {
+          const trimmed = value.trim();
+          if (!trimmed) {
+            return "Please enter your email address.";
+          }
+          if (!emailInput.validity.valid) {
+            return "Enter a valid email address.";
+          }
+          return "";
+        },
+        password(value) {
+          if (!value) {
+            return "Please enter your password.";
+          }
+          if (value.length < 8) {
+            return "Password must be at least 8 characters.";
+          }
+          return "";
+        }
+      };
+
+      function updateError(input, errorElement, message) {
+        if (message) {
+          errorElement.textContent = message;
+          input.setAttribute("aria-invalid", "true");
+        } else {
+          errorElement.textContent = "";
+          input.setAttribute("aria-invalid", "false");
+        }
+      }
+
+      function validateField(input, errorElement, key) {
+        const message = validators[key](input.value);
+        updateError(input, errorElement, message);
+        return !message;
+      }
+
+      emailInput.addEventListener("input", () => validateField(emailInput, emailError, "email"));
+      emailInput.addEventListener("blur", () => validateField(emailInput, emailError, "email"));
+
+      passwordInput.addEventListener("input", () => validateField(passwordInput, passwordError, "password"));
+      passwordInput.addEventListener("blur", () => validateField(passwordInput, passwordError, "password"));
+
+      toggleButton.addEventListener("click", () => {
+        const isPassword = passwordInput.type === "password";
+        passwordInput.type = isPassword ? "text" : "password";
+        toggleButton.textContent = isPassword ? "Hide" : "Show";
+        toggleButton.setAttribute("aria-pressed", String(isPassword));
+        passwordInput.focus({ preventScroll: true });
+      });
+
+      form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        statusMessage.textContent = "";
+        const isEmailValid = validateField(emailInput, emailError, "email");
+        const isPasswordValid = validateField(passwordInput, passwordError, "password");
+
+        if (isEmailValid && isPasswordValid) {
+          statusMessage.textContent = "Signing you in...";
+          statusMessage.style.color = "var(--color-text-muted)";
+          setTimeout(() => {
+            statusMessage.textContent = "Authentication successful. Redirecting...";
+            statusMessage.style.color = "var(--color-link)";
+          }, 600);
+        } else {
+          statusMessage.textContent = "Please fix the highlighted fields.";
+          statusMessage.style.color = "var(--color-error)";
+        }
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a glassmorphism-inspired login layout with gradient background, brand header, and accessible form controls
- implement mobile-first styling with CSS variables, focus treatments, and dark-mode adjustments
- add lightweight JavaScript for client-side validation, inline messaging, and password visibility toggling

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c8cb04cef883298943f4b132645680